### PR TITLE
Include latest security & bugfix patches by switching to the cloud-images.ubuntu.com boxes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,15 +2,21 @@
 # vi: set ft=ruby :
 
 CUSTOM_CONFIG = {
-                  "BOX_NAME"  =>  "precise64", 
-                  "BOX_URL"   =>  "http://files.vagrantup.com/precise64.box", 
+                  "BOX_NAME"  =>  "precise64-current", 
+                # This box URL includes the latest bugfix & security patches.
+                # It curently ships with VirtualBox guest additions 4.1.12,
+                # and the raring HWE stack (kernel 3.8.)
+                  "BOX_URL"   =>  "http://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box",
                   "HEADLESS"  =>  false, 
                   "DDG_PATH"  =>  "~/DuckDuckGo/repos"
                 }
 
 Vagrant.configure("2") do |config|
 
-  # precise64 ships with chef 10, so we need to upgrade it.
+  # The cloud-images.ubuntu.com boxes ship without chef,
+  # so we need to install it.
+  # If you were using a files.vagrantup.com precise64 box instead,
+  # it ships with chef 10, so it needs to be upgraded with this same line.
   config.omnibus.chef_version = :latest
 
   # Change this to the name of your Vagrant base box.

--- a/cookbooks/duckpan/recipes/default.rb
+++ b/cookbooks/duckpan/recipes/default.rb
@@ -8,6 +8,9 @@ include_recipe 'git'
 
 execute "sudo apt-get -y install perl-doc"  # required by duckpan
 
+# This step is requried with the cloud-iamges.ubuntu.com boxes
+execute "sudo apt-get -y install libssl-dev"
+
 # download the duckpan install script
 execute "su -l vagrant -c 'wget -L http://duckpan.com/install.pl -O duckpan-install.pl'"
 


### PR DESCRIPTION
As a clickbait ad might say "This neat trick lets you patch your boxes."

Before you merge this though, can you identify any regression tests that I should run? So far I have just been running "duckpan" and making sure that the manpage comes up.
