### PR TITLE
Free up space on the cloud-images.ubuntu.com boxes by removing the kerne...

### DIFF
--- a/cookbooks/duckpan/recipes/default.rb
+++ b/cookbooks/duckpan/recipes/default.rb
@@ -6,6 +6,12 @@
 include_recipe 'perl'
 include_recipe 'git'
 
+# cloud-images.ubuntu.com boxes have linux-headers-generic installed
+# (currently linux-headers-3.2.0-61-generic) installed, even though
+# the only kernel they have installed is linux-image-generic-lts-raring
+# Let's remove those headers to save space. (11.3 MB)
+execute "if ! dpkg-query --status linux-image-generic &> /dev/null; then sudo aptitude purge -y linux-headers-generic; fi"
+
 execute "sudo apt-get -y install perl-doc"  # required by duckpan
 
 # This step is requried with the cloud-iamges.ubuntu.com boxes


### PR DESCRIPTION
...l 3.2 headers (only kernel 3.8 is actually installed.)

This is such a simple change that I'll merge it without discussing. I have tested it successfully. There is a safeguard (if kernel 3.2 is installed, do not remove the kernel 3.2 headers.)

Note that this logic is not specific to duckpan, it's specific to the cloud-images.ubuntu.com boxes. If there turn out to be a lot more fixes/optimizations needed for the boxes, I'll put them in a separate recipe, or a separate cookbook.
