### PR TITLE
README.md: Fix #28 "Error during vagrant up"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project provides a Vagrant-based development setup for DuckPAN.
 
 8. Run `vagrant up`
 
-The box takes some time to stand up.  As the duckpan-install script runs, you won't see any output for a few minutes.  On my 2.7 Ghz i7 Macbook Pro, it takes 18 minutes to complete.  Refer to [Troubleshooting](#Troubleshooting) for more info.
+The box takes some time to stand up.  As the duckpan-install script runs, you won't see any output for a few minutes.  On my 2.7 Ghz i7 Macbook Pro, it takes 18 minutes to complete.  Refer to [Troubleshooting](#troubleshooting) for more info.
 
 ### Workaround for Linux distros not supported by the ChefDK
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ This project provides a Vagrant-based development setup for DuckPAN.
 
 ### Installation
 
-1. Install: [Vagrant](http://docs.vagrantup.com/v2/installation/index.html) and [Bundler](http://bundler.io/#getting-started)
+1. Install: [Vagrant](http://docs.vagrantup.com/v2/installation/index.html)
 
 2. Clone this repo
 
-3. Run `bundle install` to install Berkshelf.  
+3. Install the OS dependencies for vagrant-berkshelf. On Ubuntu, `sudo apt-get install build-essential autoconf`
 
-4. Install the dependencies for vagrant-berkshelf. On Ubuntu, `sudo apt-get install build-essential autoconf`
+4. Install the [ChefDK](https://downloads.chef.io/chef-dk/). If the ChefDK is unavailable for your Linux distro, follow the [Workaround for Linux distros not supported by the ChefDK](#chefdk-workaround) below.
 
-5. Run `vagrant plugin install vagrant-berkshelf --plugin-version=2.0.1`
+5. Run `vagrant plugin install vagrant-berkshelf`
 
 6. Run `vagrant plugin install vagrant-omnibus` so that Chef within the box can be upgraded to a version compatible with chef on the host OS.
 
@@ -21,6 +21,13 @@ This project provides a Vagrant-based development setup for DuckPAN.
 8. Run `vagrant up`
 
 The box takes some time to stand up.  As the duckpan-install script runs, you won't see any output for a few minutes.  On my 2.7 Ghz i7 Macbook Pro, it takes 18 minutes to complete.  Refer to [Troubleshooting](#Troubleshooting) for more info.
+
+### Workaround for Linux distros not supported by the ChefDK
+
+1. Run `vagrant plugin install vagrant-berkshelf --plugin-version=2.0.1` (command 1), *before* following running `vagrant plugin install berkshelf`(command 2). If you already ran command 2, run command 1 and then command 2. (Note that this results in berkshelf being installed as a vagrant-managed gem. We do not need the entire ChefDK, only berkshelf.)
+
+2. Add `~/.vagrant.d/gems/bin/` to your path. For example, at the bottom of `~/.bashrc`, add:
+`export PATH=${PATH}:~/.vagrant.d/gems/bin/`
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project provides a Vagrant-based development setup for DuckPAN.
 
 3. Install the OS dependencies for vagrant-berkshelf. On Ubuntu, `sudo apt-get install build-essential autoconf`
 
-4. Install the [ChefDK](https://downloads.chef.io/chef-dk/). If the ChefDK is unavailable for your Linux distro, follow the [Workaround for Linux distros not supported by the ChefDK](#chefdk-workaround) below.
+4. Install the [ChefDK](https://downloads.chef.io/chef-dk/). If the ChefDK is unavailable for your Linux distro, follow the [Workaround for Linux distros not supported by the ChefDK](#workaround-for-linux-distros-not-supported-by-the-chefdk) below.
 
 5. Run `vagrant plugin install vagrant-berkshelf`
 


### PR DESCRIPTION
Any comments before I merge this?

----
To fix #28, I finally found a good solution that does not require Linux users to install the binary package of the ChefDK. (vagrant-berkshelf doesn't require the entire ChefDK, only berkshelf. Although ChefDK is the preferred way to install berkshelf, only a few Linux distros are supported.)
1st, understand that with current versions of Vagrant, any gems installed by a user or sysadmin with the `gem` or `bundler` commands are ignored. Instead, vagrant installs vagrant-managed gems, and vagrant plugins use vagrant-managed gems. So if users cannot install the binary package of the ChefDK, they need to install berkshelf as a vagrant-managed gem.
The simplest way to install berkshelf as a vagrant-managed gem is to install vagrant-berkshelf 2.0.1 before installing the latest version of vagrant-berkshelf (4.0.1). So that's my solution.