### PR TITLE
Only run the action if the file exists

### DIFF
--- a/cookbooks/duckpan/recipes/default.rb
+++ b/cookbooks/duckpan/recipes/default.rb
@@ -36,8 +36,10 @@ execute "if ! dpkg-query --status linux-image-generic &> /dev/null; then sudo ap
 # manually configure eth1.
 #
 # Reference: http://askubuntu.com/questions/240632/how-to-disable-udev-net-rule-generation
-file "/etc/udev/rules.d/70-persistent-net.rules" do
-  action :delete
+if (File.file?("/etc/udev/rules.d/70-persistent-net.rules"))
+    file "/etc/udev/rules.d/70-persistent-net.rules" do
+      action :delete
+    end
 end
 file "/etc/udev/rules.d/75-persistent-net-generator.rules" do
   content "# "


### PR DESCRIPTION
I'm on a Mac and running OS X 10.11 El Capitan. I don't think that should affect this error, since it's contained within the VM, but the `action :delete` line was crashing the vagrant provision because the file didn't exist. The if statement just checks if the file exists before running the delete action. This fixed the provision for me.
